### PR TITLE
Fix app dir in docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       # - "OIDC_FLOW="
       # - "OIDC_LOGIN_BUTTON_TEXT="
     # volumes:
-      # - "/host/path/to/config.json:/app/static/config.json"
+      # - "/host/path/to/config.json:/opt/owasp/dependency-track-frontend/static/config.json"
     ports:
       - "8080:8080"
     restart: unless-stopped


### PR DESCRIPTION
### Description

Fixes a regression in docker-compose file for dtrack-frontend service

The application directory moved from `/app` to `/opt/owasp/dependency-track-frontend`, but `docker-compose.yml` still used the old one in the volume.
https://github.com/DependencyTrack/frontend/commit/d12ddfa9dcc80bb7ac262eaec70c214a77b81a38#diff-6e3cd4368541f4b438a0ce9dfe5b45e3a04426f80b43546092e76f088bd2e8dc

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

[#493](https://github.com/DependencyTrack/frontend/issues/493)

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- [~] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
